### PR TITLE
Modify Hama configuration value for synchronous client class 

### DIFF
--- a/core/src/main/java/org/apache/hama/bsp/LocalBSPRunner.java
+++ b/core/src/main/java/org/apache/hama/bsp/LocalBSPRunner.java
@@ -119,7 +119,7 @@ public class LocalBSPRunner implements JobSubmissionProtocol {
 
     conf.setClass(MessageManagerFactory.MESSAGE_MANAGER_CLASS,
         LocalMessageManager.class, MessageManager.class);
-    conf.setClass(SyncServiceFactory.SYNC_PEER_CLASS, LocalSyncClient.class,
+    conf.setClass(SyncServiceFactory.SYNC_CLIENT_CLASS, LocalSyncClient.class,
         SyncClient.class);
 
     BSPJob job = new BSPJob(new HamaConfiguration(conf), jobID);

--- a/core/src/main/java/org/apache/hama/bsp/sync/SyncServiceFactory.java
+++ b/core/src/main/java/org/apache/hama/bsp/sync/SyncServiceFactory.java
@@ -22,7 +22,7 @@ import org.apache.hadoop.util.ReflectionUtils;
 
 public class SyncServiceFactory {
   public static final String SYNC_SERVER_CLASS = "hama.sync.server.class";
-  public static final String SYNC_PEER_CLASS = "hama.sync.peer.class";
+  public static final String SYNC_CLIENT_CLASS = "hama.sync.client.class";
   public static final String SYNC_MASTER_CLASS = "hama.sync.master.class";
 
   /**
@@ -31,7 +31,7 @@ public class SyncServiceFactory {
   public static PeerSyncClient getPeerSyncClient(Configuration conf)
       throws ClassNotFoundException {
     return (PeerSyncClient) ReflectionUtils.newInstance(conf
-        .getClassByName(conf.get(SYNC_PEER_CLASS,
+        .getClassByName(conf.get(SYNC_CLIENT_CLASS,
             ZooKeeperSyncClientImpl.class.getName())), conf);
   }
 

--- a/core/src/test/java/org/apache/hama/bsp/TestBSPTaskFaults.java
+++ b/core/src/test/java/org/apache/hama/bsp/TestBSPTaskFaults.java
@@ -316,7 +316,7 @@ public class TestBSPTaskFaults extends TestCase {
       HamaConfiguration hamaConf = new HamaConfiguration();
       hamaConf.setInt(Constants.GROOM_PING_PERIOD, 200);
       hamaConf.setClass("bsp.work.class", FaulTestBSP.class, BSP.class);
-      hamaConf.setClass(SyncServiceFactory.SYNC_PEER_CLASS,
+      hamaConf.setClass(SyncServiceFactory.SYNC_CLIENT_CLASS,
           LocalBSPRunner.LocalSyncClient.class, SyncClient.class);
 
       hamaConf.setInt("bsp.master.port", 610002);
@@ -420,7 +420,7 @@ public class TestBSPTaskFaults extends TestCase {
 
     conf.setInt(Constants.GROOM_PING_PERIOD, 200);
     conf.setClass("bsp.work.class", FaulTestBSP.class, BSP.class);
-    conf.setClass(SyncServiceFactory.SYNC_PEER_CLASS,
+    conf.setClass(SyncServiceFactory.SYNC_CLIENT_CLASS,
         LocalBSPRunner.LocalSyncClient.class, SyncClient.class);
 
     int port = BSPNetUtils.getFreePort(4321 + incrementTestNumber());

--- a/core/src/test/java/org/apache/hama/bsp/TestCheckpoint.java
+++ b/core/src/test/java/org/apache/hama/bsp/TestCheckpoint.java
@@ -476,7 +476,7 @@ public class TestCheckpoint extends TestCase {
   public void testCheckpointInterval() throws Exception {
     Configuration config = new Configuration();
     System.setProperty("user.dir", "/tmp");
-    config.set(SyncServiceFactory.SYNC_PEER_CLASS,
+    config.set(SyncServiceFactory.SYNC_CLIENT_CLASS,
         TempSyncClient.class.getName());
     config.set(Constants.FAULT_TOLERANCE_CLASS,
         AsyncRcvdMsgCheckpointImpl.class.getName());
@@ -552,7 +552,7 @@ public class TestCheckpoint extends TestCase {
   @SuppressWarnings("rawtypes")
   public void testCheckpoint() throws Exception {
     Configuration config = new Configuration();
-    config.set(SyncServiceFactory.SYNC_PEER_CLASS,
+    config.set(SyncServiceFactory.SYNC_CLIENT_CLASS,
         TempSyncClient.class.getName());
     config.setBoolean(Constants.FAULT_TOLERANCE_FLAG, true);
     config.set(Constants.FAULT_TOLERANCE_CLASS,
@@ -613,7 +613,7 @@ public class TestCheckpoint extends TestCase {
 
   public void testPeerRecovery() throws Exception {
     Configuration config = new Configuration();
-    config.set(SyncServiceFactory.SYNC_PEER_CLASS,
+    config.set(SyncServiceFactory.SYNC_CLIENT_CLASS,
         TempSyncClient.class.getName());
     config.set(Constants.FAULT_TOLERANCE_CLASS,
         AsyncRcvdMsgCheckpointImpl.class.getName());


### PR DESCRIPTION
Fixed Hama configuration value for synchronous From "hama.sync.client.class" to "hama.sync.peer.class".

