### PR TITLE
Hama 900 - Added a new strategy to schedule tasks based on round robin scheme

### DIFF
--- a/core/src/main/java/org/apache/hama/bsp/JobInProgress.java
+++ b/core/src/main/java/org/apache/hama/bsp/JobInProgress.java
@@ -40,6 +40,7 @@ import org.apache.hama.bsp.ft.FaultTolerantMasterService;
 import org.apache.hama.bsp.sync.MasterSyncClient;
 import org.apache.hama.bsp.taskallocation.BSPResource;
 import org.apache.hama.bsp.taskallocation.BestEffortDataLocalTaskAllocator;
+import org.apache.hama.bsp.taskallocation.RoundRobinTaskAllocator;
 import org.apache.hama.bsp.taskallocation.TaskAllocationStrategy;
 import org.apache.hama.util.ReflectionUtils;
 
@@ -300,8 +301,13 @@ public class JobInProgress {
 
     tasksInited = true;
 
+    //CHANGED by Behroz - Uncomment this
+//    Class<?> taskAllocatorClass = conf.getClass(Constants.TASK_ALLOCATOR_CLASS,
+//        BestEffortDataLocalTaskAllocator.class, TaskAllocationStrategy.class);
+    
     Class<?> taskAllocatorClass = conf.getClass(Constants.TASK_ALLOCATOR_CLASS,
-        BestEffortDataLocalTaskAllocator.class, TaskAllocationStrategy.class);
+        RoundRobinTaskAllocator.class, TaskAllocationStrategy.class);
+    
     this.taskAllocationStrategy = (TaskAllocationStrategy) ReflectionUtils
         .newInstance(taskAllocatorClass, new Object[0]);
 

--- a/core/src/main/java/org/apache/hama/bsp/JobInProgress.java
+++ b/core/src/main/java/org/apache/hama/bsp/JobInProgress.java
@@ -298,11 +298,10 @@ public class JobInProgress {
     MasterSyncClient syncClient = master.getSyncClient();
     syncClient.registerJob(this.getJobID().toString());
 
-    tasksInited = true;    
+    tasksInited = true;
 
     Class<?> taskAllocatorClass = conf.getClass(Constants.TASK_ALLOCATOR_CLASS,
         BestEffortDataLocalTaskAllocator.class, TaskAllocationStrategy.class);
-    
     this.taskAllocationStrategy = (TaskAllocationStrategy) ReflectionUtils
         .newInstance(taskAllocatorClass, new Object[0]);
 

--- a/core/src/main/java/org/apache/hama/bsp/JobInProgress.java
+++ b/core/src/main/java/org/apache/hama/bsp/JobInProgress.java
@@ -40,7 +40,6 @@ import org.apache.hama.bsp.ft.FaultTolerantMasterService;
 import org.apache.hama.bsp.sync.MasterSyncClient;
 import org.apache.hama.bsp.taskallocation.BSPResource;
 import org.apache.hama.bsp.taskallocation.BestEffortDataLocalTaskAllocator;
-import org.apache.hama.bsp.taskallocation.RoundRobinTaskAllocator;
 import org.apache.hama.bsp.taskallocation.TaskAllocationStrategy;
 import org.apache.hama.util.ReflectionUtils;
 
@@ -299,14 +298,10 @@ public class JobInProgress {
     MasterSyncClient syncClient = master.getSyncClient();
     syncClient.registerJob(this.getJobID().toString());
 
-    tasksInited = true;
+    tasksInited = true;    
 
-    //CHANGED by Behroz - Uncomment this
-//    Class<?> taskAllocatorClass = conf.getClass(Constants.TASK_ALLOCATOR_CLASS,
-//        BestEffortDataLocalTaskAllocator.class, TaskAllocationStrategy.class);
-    
     Class<?> taskAllocatorClass = conf.getClass(Constants.TASK_ALLOCATOR_CLASS,
-        RoundRobinTaskAllocator.class, TaskAllocationStrategy.class);
+        BestEffortDataLocalTaskAllocator.class, TaskAllocationStrategy.class);
     
     this.taskAllocationStrategy = (TaskAllocationStrategy) ReflectionUtils
         .newInstance(taskAllocatorClass, new Object[0]);

--- a/core/src/main/java/org/apache/hama/bsp/taskallocation/RoundRobinTaskAllocator.java
+++ b/core/src/main/java/org/apache/hama/bsp/taskallocation/RoundRobinTaskAllocator.java
@@ -1,0 +1,159 @@
+/**
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.hama.bsp.taskallocation;
+
+import java.util.Map;
+import java.util.Map.Entry;
+import java.util.Set;
+
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hama.bsp.GroomServerStatus;
+import org.apache.hama.bsp.TaskInProgress;
+import org.apache.hama.bsp.BSPJobClient.RawSplit;
+
+public class RoundRobinTaskAllocator implements TaskAllocationStrategy {
+
+  Log LOG = LogFactory.getLog(RoundRobinTaskAllocator.class);
+
+  @Override
+  public void initialize(Configuration conf) {
+  }
+
+  /**
+   * Select grooms that has the block of data locally stored on the groom
+   * server.
+   * TODO: REMOVE -> Code taken from BestEffort. No change.
+   */
+  @Override
+  public String[] selectGrooms(Map<String, GroomServerStatus> groomStatuses,
+      Map<GroomServerStatus, Integer> taskCountInGroomMap,
+      BSPResource[] resources, TaskInProgress taskInProgress) {
+    if (!taskInProgress.canStartTask()) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Cannot start task based on id");
+      }
+      return new String[0];
+    }
+
+    RawSplit rawSplit = taskInProgress.getFileSplit();
+    if (rawSplit != null) {
+      return rawSplit.getLocations();
+    }
+    return null;
+  }
+
+  @Override
+  public GroomServerStatus getGroomToAllocate(
+      Map<String, GroomServerStatus> groomStatuses, String[] selectedGrooms,
+      Map<GroomServerStatus, Integer> taskCountInGroomMap,
+      BSPResource[] resources, TaskInProgress taskInProgress) {
+    if (!taskInProgress.canStartTask()) {
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("Exceeded allowed attempts.");
+      }
+      return null;
+    }
+
+    String groomName = null;
+    if (selectedGrooms != null) {
+      groomName = getGroomToSchedule(groomStatuses, taskCountInGroomMap, selectedGrooms);
+    }
+    
+    if (groomName == null) {
+      groomName = findGroomWithMinimumTasks(taskCountInGroomMap);
+    }
+    
+    if (groomName != null) {
+      return groomStatuses.get(groomName);
+    }
+
+    return null;
+  }
+
+  /**
+   * This operation is not supported.
+   * TODO: Taken from BestEffort. No change.
+   */
+  @Override
+  public Set<GroomServerStatus> getGroomsToAllocate(
+      Map<String, GroomServerStatus> groomStatuses, String[] selectedGrooms,
+      Map<GroomServerStatus, Integer> taskCountInGroomMap,
+      BSPResource[] resources, TaskInProgress taskInProgress) {
+    throw new UnsupportedOperationException(
+        "This API is not supported for the called API function call.");
+  }
+
+  /*
+   * This function loops through the whole list of Grooms with their task count and returns the first Groom
+   * which contains the minimum number of tasks.
+   */
+  private String findGroomWithMinimumTasks(
+      Map<GroomServerStatus, Integer> taskCountInGroomMap) {
+    Entry<GroomServerStatus, Integer> firstGroomWithMinimumTasks = null;
+    
+    for (Entry<GroomServerStatus, Integer> currentGroom : taskCountInGroomMap.entrySet()) {
+      if (firstGroomWithMinimumTasks == null || firstGroomWithMinimumTasks.getValue() > currentGroom.getValue()) {
+        firstGroomWithMinimumTasks = currentGroom;
+      }
+    }
+    
+    return (firstGroomWithMinimumTasks == null) ? null : firstGroomWithMinimumTasks.getKey().getGroomHostName();
+  }
+  
+  /**
+   * From the set of grooms given, returns the groom on which a task could be
+   * scheduled on.
+   * 
+   * @param grooms
+   * @param tasksInGroomMap
+   * @param possibleLocations
+   * @return a hostname of Groom Server.
+   */
+  private String getGroomToSchedule(Map<String, GroomServerStatus> grooms,
+      Map<GroomServerStatus, Integer> tasksInGroomMap,
+      String[] possibleLocations) {
+
+    for (String location : possibleLocations) {
+      GroomServerStatus groom = grooms.get(location);
+      if (groom == null) {
+        if (LOG.isDebugEnabled()) {
+          LOG.debug("Could not find groom for location " + location);
+        }
+        continue;
+      }
+      Integer taskInGroom = tasksInGroomMap.get(groom);
+      taskInGroom = (taskInGroom == null) ? 0 : taskInGroom;
+      if (LOG.isDebugEnabled()) {
+        LOG.debug("taskInGroom = " + taskInGroom + " max tasks = "
+            + groom.getMaxTasks() + " location = " + location
+            + " groomhostname = " + groom.getGroomHostName());
+      }
+      if (taskInGroom < groom.getMaxTasks()
+          && location.equals(groom.getGroomHostName())) {
+        return groom.getGroomHostName();
+      }
+    }
+    if (LOG.isDebugEnabled()) {
+      LOG.debug("Returning null");
+    }
+    return null;
+  }
+
+}

--- a/core/src/test/java/org/apache/hama/bsp/TestTaskAllocationRoundRobin.java
+++ b/core/src/test/java/org/apache/hama/bsp/TestTaskAllocationRoundRobin.java
@@ -1,0 +1,118 @@
+package org.apache.hama.bsp;
+
+import static org.junit.Assert.*;
+
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.LinkedHashMap;
+import java.util.List;
+import java.util.Map;
+
+import junit.framework.TestCase;
+
+import org.junit.Test;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.hadoop.util.ReflectionUtils;
+import org.apache.hama.bsp.BSPJobClient.RawSplit;
+import org.apache.hama.bsp.taskallocation.BSPResource;
+import org.apache.hama.bsp.taskallocation.RoundRobinTaskAllocator;
+import org.apache.hama.bsp.taskallocation.TaskAllocationStrategy;
+
+public class TestTaskAllocationRoundRobin extends TestCase {
+
+  public static final Log LOG = LogFactory.getLog(TestTaskAllocationRoundRobin.class);
+  
+  Configuration conf = new Configuration();
+  Map<String, GroomServerStatus> groomStatuses;
+  Map<GroomServerStatus, Integer> taskCountInGroomMap;
+  BSPResource[] resources;
+  TaskInProgress taskInProgress;
+  
+  @Override
+  protected void setUp() throws Exception {
+    super.setUp();
+
+    String[] locations = new String[] { "host6", "host4", "host3" };
+    String value = "data";
+    RawSplit split = new RawSplit();
+    split.setLocations(locations);
+    split.setBytes(value.getBytes(), 0, value.getBytes().length);
+    split.setDataLength(value.getBytes().length);
+
+    assertEquals(value.getBytes().length, (int) split.getDataLength());
+    
+    taskCountInGroomMap = new LinkedHashMap<GroomServerStatus, Integer>(10);
+    resources = new BSPResource[0];
+    BSPJob job = new BSPJob(new BSPJobID("checkpttest", 1), "/tmp");
+    JobInProgress jobProgress = new JobInProgress(job.getJobID(), conf);
+    taskInProgress = new TaskInProgress(job.getJobID(),
+        "job.xml", split, conf, jobProgress, 1);
+
+    groomStatuses = new LinkedHashMap<String, GroomServerStatus>(20);
+    
+    for (int i = 0; i < 10; ++i) {
+      String name = "host" + i;
+      
+      GroomServerStatus status = new GroomServerStatus(name,
+          new ArrayList<TaskStatus>(), 0, 3,"",name);
+      groomStatuses.put(name, status);
+      taskCountInGroomMap.put(status, 0);
+    }
+    
+  }
+
+  @Override
+  protected void tearDown() throws Exception {
+    super.tearDown();
+  }
+  
+  /*
+   * This test simulates the allocation of 30 tasks in round robin fashion. Notice that in function
+   * getGroomToAllocate null has been passed for selectedGrooms (which contains the list of grooms according to
+   * data locality). Internally getGroomToAllocate uses the findGroomWithMinimumTasks function to allocate the 
+   * tasks.
+   */
+  @Test
+  public void testRoundRobinAllocation() {
+    TaskAllocationStrategy strategy = ReflectionUtils.newInstance(conf
+        .getClass("", RoundRobinTaskAllocator.class,
+            TaskAllocationStrategy.class), conf);
+    
+    for(int i = 0; i < 30; i++) {
+      GroomServerStatus groomStatus = strategy.getGroomToAllocate(groomStatuses, null, taskCountInGroomMap, resources, taskInProgress);
+      if(groomStatus != null) {
+        taskCountInGroomMap.put(groomStatus, taskCountInGroomMap.get(groomStatus) + 1); //Increment the total tasks in it
+        
+        assertEquals("","host" + (i%10),groomStatus.getGroomHostName()); // After 10 it will start over from zero  
+      }
+    }
+  //System.out.println("Groom Selected -> " + groomStatus.getGroomHostName());
+  }
+  
+  /*
+   * Allocation according to data locality still works the same way. No change made in that part.
+   */
+  @Test
+  public void testRoundRobinDataLocality() throws Exception {
+    
+    TaskAllocationStrategy strategy = ReflectionUtils.newInstance(conf
+        .getClass("", RoundRobinTaskAllocator.class,
+            TaskAllocationStrategy.class), conf);
+
+    String[] hosts = strategy.selectGrooms(groomStatuses, taskCountInGroomMap,
+        resources, taskInProgress);
+    
+    List<String> list = new ArrayList<String>();
+
+    for (int i = 0; i < hosts.length; ++i) {
+      list.add(hosts[i]);
+    }
+
+    assertTrue(list.contains("host6"));
+    assertTrue(list.contains("host3"));
+    assertTrue(list.contains("host4"));
+  }
+
+}


### PR DESCRIPTION
In this pull request, I have implemented the TaskAllocationStrategy to schedule tasks equally on cluster. 
I ran multiple tests on my cluster including the PI example and my own algorithm and everything was alright. 
Following snapshot shows one such example. On my cluster with 9 machines supporting 54 tasks, I ran a job with 18 tasks. In the screenshot you can see the equal distribution in cluster with each machine only running 2 tasks.
![roundrobin-18 tasks-9 grooms](https://cloud.githubusercontent.com/assets/4642104/12373184/4ff4c0fe-bc71-11e5-8275-56434da8b4a8.png)

